### PR TITLE
travis-ci config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: groovy
+
+sudo: false
+
+script:
+  - gradle cucumber
+

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 <h3>Cucumber JVM with Gradle and Groovy Skeleton</h3>
 
+[![Build Status](https://travis-ci.org/d-led/cucumber-groovy-gradle.svg?branch=master)](https://travis-ci.org/d-led/cucumber-groovy-gradle)
+
 You will need to have a recent Java JDK installed on your system and system path.
 
 From a command line run:


### PR DESCRIPTION
given the today's dockerized travis-ci build, it might make sense to have a travis-ci hook and a badge for quick tryouts. Substitute `d-led` in the badge for the correct name after configuring travis-ci

[![Build Status](https://travis-ci.org/d-led/cucumber-groovy-gradle.svg?branch=master)](https://travis-ci.org/d-led/cucumber-groovy-gradle)
